### PR TITLE
Add `#![no_std]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
+#![no_std]
+
 pub struct Assert<const COND: bool> {}
 
 pub trait IsTrue {}


### PR DESCRIPTION
Allow this crate to be used in `no_std` contexts.
